### PR TITLE
Add support for multiple tokenizers.

### DIFF
--- a/gpt/Cargo.lock
+++ b/gpt/Cargo.lock
@@ -790,6 +790,8 @@ dependencies = [
  "candle-core",
  "candle-nn",
  "rand",
+ "rmp-serde",
+ "serde",
 ]
 
 [[package]]
@@ -1281,6 +1283,28 @@ name = "reborrow"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
+
+[[package]]
+name = "rmp"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
+]
 
 [[package]]
 name = "rustc-demangle"

--- a/gpt/cli/src/args.rs
+++ b/gpt/cli/src/args.rs
@@ -1,12 +1,23 @@
 use crate::device::Device;
+use anyhow::Result;
+use candle_core::Tensor;
 use clap::{Parser, ValueEnum};
+use gpt_core::char_tokenizer::CharTokenizer;
 use gpt_core::language_model_builder::LanguageModelBuilder;
+use gpt_core::pair_tokenizers::CharPairTokenizer;
+use gpt_core::tokenizer::Tokenizer;
 use gpt_core::transformer_language_model::TransformerLanguageModelOptions;
 
 #[derive(Debug, Clone, ValueEnum)]
 pub enum Model {
     Bigram,
     Transformer,
+}
+
+#[derive(Debug, Clone, ValueEnum)]
+pub enum TokenizerType {
+    Char,
+    CharPair,
 }
 
 #[derive(Parser)]
@@ -53,6 +64,13 @@ pub struct Args {
     #[arg(long, value_enum, default_value_t = Model::Transformer)]
     pub model: Model,
 
+    #[arg(long, value_enum, default_value_t = TokenizerType::Char)]
+    pub tokenizer: TokenizerType,
+
+    /// Size of tokenizer vocabulary (not used by char tokenizer).
+    #[arg(long, default_value_t = 300)]
+    pub vocab_size: usize,
+
     /// Number of training examples per batch.
     #[arg(long, default_value_t = 32)]
     pub batch_size: usize,
@@ -97,5 +115,25 @@ impl Args {
                 })
             }
         }
+    }
+
+    pub fn create_tokenizer_and_training_data(
+        &self,
+        device: &candle_core::Device,
+    ) -> Result<(Box<dyn Tokenizer>, Tensor)> {
+        let training_corpus = std::fs::read_to_string(&self.corpus)?;
+        let tokenizer: Box<dyn Tokenizer> = match self.tokenizer {
+            TokenizerType::Char => Box::new(CharTokenizer::from_string(&training_corpus)?),
+            TokenizerType::CharPair => {
+                let initial_vocab = CharTokenizer::from_string(&training_corpus)?;
+                Box::new(CharPairTokenizer::new(
+                    &training_corpus,
+                    initial_vocab,
+                    self.vocab_size,
+                )?)
+            }
+        };
+        let data = Tensor::new(tokenizer.encode(&training_corpus)?, device)?;
+        Ok((tokenizer, data))
     }
 }

--- a/gpt/cli/src/args.rs
+++ b/gpt/cli/src/args.rs
@@ -15,7 +15,7 @@ pub enum Model {
 }
 
 #[derive(Debug, Clone, ValueEnum)]
-pub enum TokenizerType {
+pub enum ArgsTokenizerType {
     Char,
     CharPairAlpha,
 }
@@ -64,8 +64,8 @@ pub struct Args {
     #[arg(long, value_enum, default_value_t = Model::Transformer)]
     pub model: Model,
 
-    #[arg(long, value_enum, default_value_t = TokenizerType::Char)]
-    pub tokenizer: TokenizerType,
+    #[arg(long, value_enum, default_value_t = ArgsTokenizerType::Char)]
+    pub tokenizer: ArgsTokenizerType,
 
     /// Size of tokenizer vocabulary (not used by char tokenizer).
     #[arg(long, default_value_t = 300)]
@@ -124,8 +124,8 @@ impl Args {
         let training_corpus = std::fs::read_to_string(&self.corpus)?;
         let original_len = training_corpus.len();
         let tokenizer: Box<dyn Tokenizer> = match self.tokenizer {
-            TokenizerType::Char => Box::new(CharTokenizer::from_string(&training_corpus)?),
-            TokenizerType::CharPairAlpha => {
+            ArgsTokenizerType::Char => Box::new(CharTokenizer::from_string(&training_corpus)?),
+            ArgsTokenizerType::CharPairAlpha => {
                 let initial_vocab = CharTokenizer::from_string(&training_corpus)?;
                 Box::new(CharPairTokenizer::new(
                     &training_corpus,

--- a/gpt/cli/src/args.rs
+++ b/gpt/cli/src/args.rs
@@ -4,7 +4,7 @@ use candle_core::Tensor;
 use clap::{Parser, ValueEnum};
 use gpt_core::char_tokenizer::CharTokenizer;
 use gpt_core::language_model_builder::LanguageModelBuilder;
-use gpt_core::pair_tokenizers::CharPairTokenizer;
+use gpt_core::pair_tokenizers::{CharPairFilter, CharPairTokenizer};
 use gpt_core::tokenizer::Tokenizer;
 use gpt_core::transformer_language_model::TransformerLanguageModelOptions;
 
@@ -17,7 +17,7 @@ pub enum Model {
 #[derive(Debug, Clone, ValueEnum)]
 pub enum TokenizerType {
     Char,
-    CharPair,
+    CharPairAlpha,
 }
 
 #[derive(Parser)]
@@ -124,12 +124,13 @@ impl Args {
         let training_corpus = std::fs::read_to_string(&self.corpus)?;
         let tokenizer: Box<dyn Tokenizer> = match self.tokenizer {
             TokenizerType::Char => Box::new(CharTokenizer::from_string(&training_corpus)?),
-            TokenizerType::CharPair => {
+            TokenizerType::CharPairAlpha => {
                 let initial_vocab = CharTokenizer::from_string(&training_corpus)?;
                 Box::new(CharPairTokenizer::new(
                     &training_corpus,
                     initial_vocab,
                     self.vocab_size,
+                    Some(CharPairFilter::AlphaOnly),
                 )?)
             }
         };

--- a/gpt/cli/src/args.rs
+++ b/gpt/cli/src/args.rs
@@ -122,6 +122,7 @@ impl Args {
         device: &candle_core::Device,
     ) -> Result<(Box<dyn Tokenizer>, Tensor)> {
         let training_corpus = std::fs::read_to_string(&self.corpus)?;
+        let original_len = training_corpus.len();
         let tokenizer: Box<dyn Tokenizer> = match self.tokenizer {
             TokenizerType::Char => Box::new(CharTokenizer::from_string(&training_corpus)?),
             TokenizerType::CharPairAlpha => {
@@ -134,7 +135,13 @@ impl Args {
                 )?)
             }
         };
-        let data = Tensor::new(tokenizer.encode(&training_corpus)?, device)?;
+        let tokens = tokenizer.encode(&training_corpus)?;
+        let tokens_len = tokens.len();
+        let data = Tensor::new(tokens, device)?;
+        println!(
+            "Tokenizer training data compression ratio: {:.2}",
+            original_len as f32 / tokens_len as f32
+        );
         Ok((tokenizer, data))
     }
 }

--- a/gpt/cli/src/main.rs
+++ b/gpt/cli/src/main.rs
@@ -15,6 +15,7 @@ use clap::Parser;
 use gpt_core::{
     char_tokenizer::CHAR_TOKENIZER_VOCABULARY_KEY,
     language_model::{LanguageGenerator, language_loss},
+    tokenizer::Tokenizer,
 };
 use gpt_core::{char_tokenizer::CharTokenizer, util::load_data_from_safetensors};
 use gpt_core::{

--- a/gpt/cli/src/main.rs
+++ b/gpt/cli/src/main.rs
@@ -189,10 +189,7 @@ fn main() -> Result<()> {
             DType::U32,
             &device,
         )?;
-        varmap.set_one(
-            CHAR_TOKENIZER_VOCABULARY_KEY,
-            tokenizer.clone().into_tensor(&device)?,
-        )?;
+        varmap.set_one(CHAR_TOKENIZER_VOCABULARY_KEY, tokenizer.as_tensor(&device)?)?;
         varmap.save(save)?;
     }
 

--- a/gpt/cli/src/main.rs
+++ b/gpt/cli/src/main.rs
@@ -13,16 +13,14 @@ use candle_core::{DType, IndexOp, Tensor};
 use candle_nn::{AdamW, Optimizer, ParamsAdamW, VarBuilder, VarMap};
 use clap::Parser;
 use gpt_core::{
-    char_tokenizer::CharTokenizer, tokenizer::TOKENIZER_VOCABULARY_KEY,
-    util::load_data_from_safetensors,
+    char_tokenizer::CHAR_TOKENIZER_VOCABULARY_KEY,
+    language_model::{LanguageGenerator, language_loss},
+    tokenizer::Tokenizer,
 };
+use gpt_core::{char_tokenizer::CharTokenizer, util::load_data_from_safetensors};
 use gpt_core::{
     language_model::LanguageModel,
     util::{count_params, print_gradient_info},
-};
-use gpt_core::{
-    language_model::{LanguageGenerator, language_loss},
-    tokenizer::Tokenizer,
 };
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use rand::{Rng, SeedableRng, rngs::StdRng};
@@ -56,8 +54,8 @@ fn main() -> Result<()> {
         // an UNSAFE block...
         let data = unsafe { candle_core::safetensors::MmapedSafetensors::new(load)? };
 
-        if let Ok(tokenizer_tensor) = data.load(TOKENIZER_VOCABULARY_KEY, &device) {
-            safetensors_tokenizer = Some(CharTokenizer::try_from(tokenizer_tensor)?);
+        if let Ok(tokenizer_tensor) = data.load(CHAR_TOKENIZER_VOCABULARY_KEY, &device) {
+            safetensors_tokenizer = Some(CharTokenizer::from_tensor(&tokenizer_tensor)?);
         }
         Some(data)
     } else {
@@ -186,13 +184,15 @@ fn main() -> Result<()> {
         // we perform inference anyways so it's not that big a deal.
         varmap.get(
             (tokenizer.len(),),
-            TOKENIZER_VOCABULARY_KEY,
+            CHAR_TOKENIZER_VOCABULARY_KEY,
             candle_nn::Init::Const(0.0),
             DType::U32,
             &device,
         )?;
-        let tensor: Tensor = tokenizer.clone().try_into()?;
-        varmap.set_one(TOKENIZER_VOCABULARY_KEY, tensor)?;
+        varmap.set_one(
+            CHAR_TOKENIZER_VOCABULARY_KEY,
+            tokenizer.clone().into_tensor(&device)?,
+        )?;
         varmap.save(save)?;
     }
 

--- a/gpt/cli/src/main.rs
+++ b/gpt/cli/src/main.rs
@@ -66,8 +66,7 @@ fn main() -> Result<()> {
     let mut training_tokenizer: Option<Box<dyn Tokenizer>> = None;
 
     if args.epochs > 0 || safetensors_tokenizer.is_none() {
-        let (tokenizer, training_data) =
-            generate_training_data(std::fs::read_to_string(&args.corpus)?, &device)?;
+        let (tokenizer, training_data) = args.create_tokenizer_and_training_data(&device)?;
         if args.epochs > 0 {
             training_info = Some((args.epochs, training_data));
         }
@@ -232,15 +231,6 @@ fn add_extension_if_missing(filename: &String, extension: &str) -> String {
 pub enum TrainingSet {
     Train,
     Val,
-}
-
-fn generate_training_data(
-    training_corpus: String,
-    device: &candle_core::Device,
-) -> Result<(Box<dyn Tokenizer>, Tensor)> {
-    let tokenizer = CharTokenizer::from_string(&training_corpus)?;
-    let data = Tensor::new(tokenizer.encode(&training_corpus)?, &device)?;
-    Ok((Box::new(tokenizer), data))
 }
 
 pub struct Trainer {

--- a/gpt/cli/src/main.rs
+++ b/gpt/cli/src/main.rs
@@ -94,6 +94,9 @@ fn main() -> Result<()> {
     let context = tokenizer.encode(&args.context)?;
     let vocab_size = tokenizer.len();
     println!("Initialized tokenizer with {} tokens.", vocab_size);
+    if args.vars {
+        println!("Tokenizer vocabulary: {}", tokenizer.debug_vocab());
+    }
 
     // let (xs, ys) = get_batch(&train_data, &mut rng)?;
     // println!("xs:\n{xs}\nys:\n{ys}");

--- a/gpt/cli/src/main.rs
+++ b/gpt/cli/src/main.rs
@@ -53,7 +53,7 @@ fn main() -> Result<()> {
         // an UNSAFE block...
         let data = unsafe { candle_core::safetensors::MmapedSafetensors::new(load)? };
 
-        if let Ok(char_tokenizer) = TokenizerType::Char.load(&data, &device) {
+        if let Ok(char_tokenizer) = TokenizerType::load_any(&data, &device) {
             safetensors_tokenizer = Some(char_tokenizer);
         }
         Some(data)

--- a/gpt/cli/src/main.rs
+++ b/gpt/cli/src/main.rs
@@ -66,6 +66,10 @@ fn main() -> Result<()> {
     let mut training_tokenizer: Option<Box<dyn Tokenizer>> = None;
 
     if args.epochs > 0 || safetensors_tokenizer.is_none() {
+        println!(
+            "Initializing tokenizer {:?} with training data...",
+            args.tokenizer
+        );
         let (tokenizer, training_data) = args.create_tokenizer_and_training_data(&device)?;
         if args.epochs > 0 {
             training_info = Some((args.epochs, training_data));

--- a/gpt/cli/src/main.rs
+++ b/gpt/cli/src/main.rs
@@ -181,6 +181,7 @@ fn main() -> Result<()> {
     if let Some(save) = &args.save {
         let save = normalize_safetensors_filename(save);
         println!("Saving weights to {save}.");
+        let tensor = tokenizer.as_tensor(&device)?;
         // We need to get the key, which creates it, before we can actually
         // set it (this feels very weird).
         //
@@ -189,13 +190,13 @@ fn main() -> Result<()> {
         // real variable, when it's actually not. But this is right before
         // we perform inference anyways so it's not that big a deal.
         varmap.get(
-            (tokenizer.len(),),
+            tensor.shape(),
             TOKENIZER_VOCABULARY_KEY,
             candle_nn::Init::Const(0.0),
-            DType::U32,
+            tensor.dtype(),
             &device,
         )?;
-        varmap.set_one(TOKENIZER_VOCABULARY_KEY, tokenizer.as_tensor(&device)?)?;
+        varmap.set_one(TOKENIZER_VOCABULARY_KEY, tensor)?;
         varmap.save(save)?;
     }
 

--- a/gpt/cli/src/main.rs
+++ b/gpt/cli/src/main.rs
@@ -12,15 +12,15 @@ use args::Args;
 use candle_core::{DType, IndexOp, Tensor};
 use candle_nn::{AdamW, Optimizer, ParamsAdamW, VarBuilder, VarMap};
 use clap::Parser;
-use gpt_core::{
-    char_tokenizer::CHAR_TOKENIZER_VOCABULARY_KEY,
-    language_model::{LanguageGenerator, language_loss},
-    tokenizer::Tokenizer,
-};
 use gpt_core::{char_tokenizer::CharTokenizer, util::load_data_from_safetensors};
 use gpt_core::{
     language_model::LanguageModel,
     util::{count_params, print_gradient_info},
+};
+use gpt_core::{
+    language_model::{LanguageGenerator, language_loss},
+    tokenizer::TOKENIZER_VOCABULARY_KEY,
+    tokenizer::Tokenizer,
 };
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use rand::{Rng, SeedableRng, rngs::StdRng};
@@ -54,7 +54,7 @@ fn main() -> Result<()> {
         // an UNSAFE block...
         let data = unsafe { candle_core::safetensors::MmapedSafetensors::new(load)? };
 
-        if let Ok(tokenizer_tensor) = data.load(CHAR_TOKENIZER_VOCABULARY_KEY, &device) {
+        if let Ok(tokenizer_tensor) = data.load(TOKENIZER_VOCABULARY_KEY, &device) {
             safetensors_tokenizer = Some(Box::new(CharTokenizer::from_tensor(&tokenizer_tensor)?));
         }
         Some(data)
@@ -184,12 +184,12 @@ fn main() -> Result<()> {
         // we perform inference anyways so it's not that big a deal.
         varmap.get(
             (tokenizer.len(),),
-            CHAR_TOKENIZER_VOCABULARY_KEY,
+            TOKENIZER_VOCABULARY_KEY,
             candle_nn::Init::Const(0.0),
             DType::U32,
             &device,
         )?;
-        varmap.set_one(CHAR_TOKENIZER_VOCABULARY_KEY, tokenizer.as_tensor(&device)?)?;
+        varmap.set_one(TOKENIZER_VOCABULARY_KEY, tokenizer.as_tensor(&device)?)?;
         varmap.save(save)?;
     }
 

--- a/gpt/gpt-core/Cargo.toml
+++ b/gpt/gpt-core/Cargo.toml
@@ -9,3 +9,5 @@ approx = {workspace = true}
 candle-core = {workspace = true}
 candle-nn = {workspace = true}
 rand = {workspace = true}
+rmp-serde = "1.3.0"
+serde = { version = "1.0.219", features = ["derive"] }

--- a/gpt/gpt-core/examples/bytepair/main.rs
+++ b/gpt/gpt-core/examples/bytepair/main.rs
@@ -1,6 +1,9 @@
 use std::{collections::HashMap, iter::zip};
 
-use gpt_core::pair_tokenizers::{BytePairTokenizer, merge};
+use gpt_core::{
+    pair_tokenizers::{BytePairTokenizer, merge},
+    tokenizer::Tokenizer,
+};
 
 /// This is the first paragraph from
 /// https://www.reedbeta.com/blog/programmers-intro-to-unicode/
@@ -49,7 +52,7 @@ pub fn main() {
     );
 
     let tokenizer = BytePairTokenizer::new(UNICODE_STR, 257).unwrap();
-    assert_eq!(tokenizer.encode(UNICODE_STR), new_tokens);
+    assert_eq!(tokenizer.encode(UNICODE_STR).unwrap(), new_tokens);
     println!("BytePairTokenizer::encode() works!");
     assert_eq!(
         tokenizer.decode(&new_tokens).unwrap(),

--- a/gpt/gpt-core/src/char_tokenizer.rs
+++ b/gpt/gpt-core/src/char_tokenizer.rs
@@ -114,6 +114,10 @@ impl Tokenizer for CharTokenizer {
         Ok(Tensor::from_vec(vec, (len,), device)?)
     }
 
+    fn tokenizer_type(&self) -> crate::tokenizer::TokenizerType {
+        crate::tokenizer::TokenizerType::Char
+    }
+
     fn debug_vocab(&self) -> String {
         let str: String = self.clone().into_char_vec().iter().collect();
         format!("{:?}", str)

--- a/gpt/gpt-core/src/char_tokenizer.rs
+++ b/gpt/gpt-core/src/char_tokenizer.rs
@@ -113,6 +113,11 @@ impl Tokenizer for CharTokenizer {
             .collect();
         Ok(Tensor::from_vec(vec, (len,), device)?)
     }
+
+    fn debug_vocab(&self) -> String {
+        let str: String = self.clone().into_char_vec().iter().collect();
+        format!("{:?}", str)
+    }
 }
 
 #[cfg(test)]

--- a/gpt/gpt-core/src/char_tokenizer.rs
+++ b/gpt/gpt-core/src/char_tokenizer.rs
@@ -111,9 +111,10 @@ impl Tokenizer for CharTokenizer {
 
     /// Returns a one-dimensional tensor with each character in the vocabulary
     /// represented by a unicode scalar.
-    fn into_tensor(self, device: &Device) -> Result<Tensor> {
+    fn as_tensor(&self, device: &Device) -> Result<Tensor> {
         let len = self.ctoi.len();
         let vec = self
+            .clone()
             .into_char_vec()
             .into_iter()
             .map(|char| char as u32)
@@ -256,7 +257,7 @@ mod tests {
     fn test_from_into_tensor_works() {
         let input = String::from("abc");
         let tokenizer = CharTokenizer::from_string(&input).unwrap();
-        let tensor = tokenizer.into_tensor(&Device::Cpu).unwrap();
+        let tensor = tokenizer.as_tensor(&Device::Cpu).unwrap();
         assert_eq!(tensor.to_vec1::<u32>().unwrap(), vec![97, 98, 99]);
         let tokenizer = CharTokenizer::from_tensor(&tensor).unwrap();
         assert_eq!(tokenizer.into_char_vec(), vec!['a', 'b', 'c']);

--- a/gpt/gpt-core/src/char_tokenizer.rs
+++ b/gpt/gpt-core/src/char_tokenizer.rs
@@ -8,6 +8,14 @@ use candle_core::{Device, Tensor};
 
 use crate::tokenizer::Tokenizer;
 
+/// Key in safetensors file to store tokenizer vocabulary.
+/// Prefixing it with "BUFFER." because this is similar to a pytorch
+/// buffer and we want to make it obvious that it's not a trainable
+/// model parameter.
+///
+/// The key's value is meant to be a Tensor returned by `Tokenizer::into_tensor()`.
+pub const CHAR_TOKENIZER_VOCABULARY_KEY: &'static str = "BUFFER.tokenizer_vocabulary";
+
 /// Character-level tokenizer in the style of Karpathy's
 /// neural net lectures.
 #[derive(Clone)]
@@ -44,7 +52,7 @@ impl CharTokenizer {
 
     /// Given a one-dimensional tensor with each character representing a
     /// unicode scalar, returns the tokenizer for it.
-    fn from_tensor(tensor: &Tensor) -> Result<Self> {
+    pub fn from_tensor(tensor: &Tensor) -> Result<Self> {
         let chars: Result<Vec<char>, CharTryFromError> = tensor
             .to_vec1::<u32>()?
             .iter()
@@ -55,7 +63,7 @@ impl CharTokenizer {
 
     /// Returns a one-dimensional tensor with each character in the vocabulary
     /// represented by a unicode scalar.
-    fn into_tensor(self, device: &Device) -> Result<Tensor> {
+    pub fn into_tensor(self, device: &Device) -> Result<Tensor> {
         let len = self.ctoi.len();
         let vec = self
             .into_char_vec()
@@ -70,22 +78,6 @@ impl CharTokenizer {
             return Err(anyhow!("'{}' is not a valid token", token));
         };
         Ok(char)
-    }
-}
-
-impl TryFrom<Tensor> for CharTokenizer {
-    type Error = anyhow::Error;
-
-    fn try_from(value: Tensor) -> std::result::Result<Self, Self::Error> {
-        CharTokenizer::from_tensor(&value)
-    }
-}
-
-impl TryInto<Tensor> for CharTokenizer {
-    type Error = anyhow::Error;
-
-    fn try_into(self) -> std::result::Result<Tensor, Self::Error> {
-        self.into_tensor(&Device::Cpu)
     }
 }
 

--- a/gpt/gpt-core/src/char_tokenizer.rs
+++ b/gpt/gpt-core/src/char_tokenizer.rs
@@ -86,10 +86,10 @@ impl Tokenizer for CharTokenizer {
         self.ctoi.len()
     }
 
-    fn encode<T: AsRef<str>>(&self, content: T) -> Result<Vec<u32>> {
-        let mut result = Vec::with_capacity(content.as_ref().len());
+    fn encode(&self, content: &str) -> Result<Vec<u32>> {
+        let mut result = Vec::with_capacity(content.len());
 
-        for char in content.as_ref().chars() {
+        for char in content.chars() {
             let Some(token) = self.ctoi.get(&char) else {
                 return Err(anyhow!("'{}' is not a valid character", char));
             };
@@ -99,10 +99,10 @@ impl Tokenizer for CharTokenizer {
         Ok(result)
     }
 
-    fn encode_lossy<T: AsRef<str>>(&self, content: T) -> Vec<u32> {
-        let mut result = Vec::with_capacity(content.as_ref().len());
+    fn encode_lossy(&self, content: &str) -> Vec<u32> {
+        let mut result = Vec::with_capacity(content.len());
 
-        for char in content.as_ref().chars() {
+        for char in content.chars() {
             if let Some(&token) = self.ctoi.get(&char) {
                 result.push(token);
             };
@@ -260,5 +260,11 @@ mod tests {
         assert_eq!(tensor.to_vec1::<u32>().unwrap(), vec![97, 98, 99]);
         let tokenizer = CharTokenizer::from_tensor(&tensor).unwrap();
         assert_eq!(tokenizer.into_char_vec(), vec!['a', 'b', 'c']);
+    }
+
+    #[test]
+    fn test_trait_object_works() {
+        let _trait_obj: Box<dyn Tokenizer> =
+            Box::new(CharTokenizer::from_string(&"hi".to_owned()).unwrap());
     }
 }

--- a/gpt/gpt-core/src/char_tokenizer.rs
+++ b/gpt/gpt-core/src/char_tokenizer.rs
@@ -8,14 +8,6 @@ use candle_core::{Device, Tensor};
 
 use crate::tokenizer::Tokenizer;
 
-/// Key in safetensors file to store tokenizer vocabulary.
-/// Prefixing it with "BUFFER." because this is similar to a pytorch
-/// buffer and we want to make it obvious that it's not a trainable
-/// model parameter.
-///
-/// The key's value is meant to be a Tensor returned by `Tokenizer::into_tensor()`.
-pub const CHAR_TOKENIZER_VOCABULARY_KEY: &'static str = "BUFFER.tokenizer_vocabulary";
-
 /// Character-level tokenizer in the style of Karpathy's
 /// neural net lectures.
 #[derive(Clone)]

--- a/gpt/gpt-core/src/char_tokenizer.rs
+++ b/gpt/gpt-core/src/char_tokenizer.rs
@@ -61,18 +61,6 @@ impl CharTokenizer {
         Ok(CharTokenizer::from_char_vec(chars?)?)
     }
 
-    /// Returns a one-dimensional tensor with each character in the vocabulary
-    /// represented by a unicode scalar.
-    pub fn into_tensor(self, device: &Device) -> Result<Tensor> {
-        let len = self.ctoi.len();
-        let vec = self
-            .into_char_vec()
-            .into_iter()
-            .map(|char| char as u32)
-            .collect();
-        Ok(Tensor::from_vec(vec, (len,), device)?)
-    }
-
     pub fn decode_char(&self, token: u32) -> Result<char> {
         let Some(&char) = self.itoc.get(&token) else {
             return Err(anyhow!("'{}' is not a valid token", token));
@@ -119,6 +107,18 @@ impl Tokenizer for CharTokenizer {
         }
 
         Ok(result)
+    }
+
+    /// Returns a one-dimensional tensor with each character in the vocabulary
+    /// represented by a unicode scalar.
+    fn into_tensor(self, device: &Device) -> Result<Tensor> {
+        let len = self.ctoi.len();
+        let vec = self
+            .into_char_vec()
+            .into_iter()
+            .map(|char| char as u32)
+            .collect();
+        Ok(Tensor::from_vec(vec, (len,), device)?)
     }
 }
 

--- a/gpt/gpt-core/src/language_model.rs
+++ b/gpt/gpt-core/src/language_model.rs
@@ -5,7 +5,7 @@ use candle_nn::{Module, loss::cross_entropy, ops::softmax};
 use rand::rngs::StdRng;
 
 use crate::{
-    char_tokenizer::CharTokenizer,
+    tokenizer::Tokenizer,
     util::{assert_equal_tensors, multinomial},
 };
 
@@ -71,13 +71,13 @@ impl LanguageGenerator {
         self.context.push(token);
     }
 
-    pub fn next_char(
+    pub fn next_token(
         &mut self,
         rng: &mut StdRng,
-        tokenizer: &CharTokenizer,
+        tokenizer: &Box<dyn Tokenizer>,
         temperature: f32,
         device: &Device,
-    ) -> Result<char> {
+    ) -> Result<String> {
         let logits = self.logits(device)?;
         let token = if temperature == 0.0 {
             logits.argmax(1)?.get(0)?.to_scalar()?
@@ -89,6 +89,6 @@ impl LanguageGenerator {
             multinomial(&sm, rng)?
         };
         self.push(token);
-        Ok(tokenizer.decode_char(token)?)
+        Ok(tokenizer.decode(&vec![token])?)
     }
 }

--- a/gpt/gpt-core/src/lib.rs
+++ b/gpt/gpt-core/src/lib.rs
@@ -3,5 +3,6 @@ pub mod char_tokenizer;
 pub mod language_model;
 pub mod language_model_builder;
 pub mod pair_tokenizers;
+pub mod tokenizer;
 pub mod transformer_language_model;
 pub mod util;

--- a/gpt/gpt-core/src/pair_tokenizers.rs
+++ b/gpt/gpt-core/src/pair_tokenizers.rs
@@ -2,7 +2,7 @@ use std::{cmp::Ordering, collections::HashMap, iter::zip};
 
 use anyhow::{Result, anyhow};
 
-use crate::char_tokenizer::CharTokenizer;
+use crate::{char_tokenizer::CharTokenizer, tokenizer::Tokenizer};
 
 pub fn merge(tokens: &[u32], pair: (u32, u32), pair_token_id: u32) -> Vec<u32> {
     let mut new_tokens = Vec::with_capacity(tokens.len());

--- a/gpt/gpt-core/src/pair_tokenizers.rs
+++ b/gpt/gpt-core/src/pair_tokenizers.rs
@@ -309,11 +309,16 @@ impl Tokenizer for CharPairTokenizer {
     }
 
     fn debug_vocab(&self) -> String {
-        let result: Vec<String> = self
-            .token_to_chars_map
-            .values()
-            .map(|chars| chars.iter().collect())
-            .collect();
+        let mut result: Vec<String> = Vec::with_capacity(self.token_to_chars_map.len());
+        for token in 0..self.token_to_chars_map.len() {
+            let str: String = self
+                .token_to_chars_map
+                .get(&(token as u32))
+                .unwrap()
+                .iter()
+                .collect();
+            result.push(str);
+        }
         format!("{:?}", result)
     }
 }

--- a/gpt/gpt-core/src/pair_tokenizers.rs
+++ b/gpt/gpt-core/src/pair_tokenizers.rs
@@ -175,6 +175,10 @@ impl Tokenizer for BytePairTokenizer {
     fn as_tensor(&self, _device: &candle_core::Device) -> Result<candle_core::Tensor> {
         todo!()
     }
+
+    fn debug_vocab(&self) -> String {
+        todo!()
+    }
 }
 
 pub struct CharPairTokenizer {
@@ -257,6 +261,15 @@ impl Tokenizer for CharPairTokenizer {
 
     fn as_tensor(&self, _device: &candle_core::Device) -> Result<candle_core::Tensor> {
         todo!()
+    }
+
+    fn debug_vocab(&self) -> String {
+        let result: Vec<String> = self
+            .token_to_chars_map
+            .values()
+            .map(|chars| chars.iter().collect())
+            .collect();
+        format!("{:?}", result)
     }
 }
 

--- a/gpt/gpt-core/src/pair_tokenizers.rs
+++ b/gpt/gpt-core/src/pair_tokenizers.rs
@@ -27,10 +27,10 @@ pub fn merge(tokens: &[u32], pair: (u32, u32), pair_token_id: u32) -> Vec<u32> {
     new_tokens
 }
 
-fn get_most_common_pair(tokens: &[u32]) -> Result<(u32, u32)> {
+fn get_most_common_pair(tokens: &[u32]) -> Option<(u32, u32)> {
     let mut counts: HashMap<(u32, u32), usize> = HashMap::new();
     if tokens.len() < 2 {
-        return Err(anyhow!("tokens does not contain any pairs!"));
+        return None;
     }
     for (&a, &b) in zip(tokens.iter(), tokens[1..].iter()) {
         let pair = (a, b);
@@ -54,7 +54,11 @@ fn get_most_common_pair(tokens: &[u32]) -> Result<(u32, u32)> {
         }
     });
 
-    Ok(all[0].0)
+    if let Some((pair, _)) = all.get(0) {
+        Some(*pair)
+    } else {
+        None
+    }
 }
 
 fn pair_compress(mut tokens: Vec<u32>, pair_to_token_map: &HashMap<(u32, u32), u32>) -> Vec<u32> {
@@ -118,7 +122,9 @@ impl BytePairTokenizer {
         }
 
         while curr_vocab_size < vocab_size {
-            let pair = get_most_common_pair(&tokens)?;
+            let Some(pair) = get_most_common_pair(&tokens) else {
+                break;
+            };
             let new_token_id = curr_vocab_size as u32;
             curr_vocab_size += 1;
             pair_to_token_map.insert(pair, new_token_id);
@@ -210,7 +216,9 @@ impl CharPairTokenizer {
         }
 
         while curr_vocab_size < vocab_size {
-            let pair = get_most_common_pair(&tokens)?;
+            let Some(pair) = get_most_common_pair(&tokens) else {
+                break;
+            };
             let new_token_id = curr_vocab_size as u32;
             curr_vocab_size += 1;
             pair_to_token_map.insert(pair, new_token_id);

--- a/gpt/gpt-core/src/pair_tokenizers.rs
+++ b/gpt/gpt-core/src/pair_tokenizers.rs
@@ -172,7 +172,7 @@ impl Tokenizer for BytePairTokenizer {
         Ok(String::from_utf8(result)?)
     }
 
-    fn into_tensor(self, _device: &candle_core::Device) -> Result<candle_core::Tensor> {
+    fn as_tensor(&self, _device: &candle_core::Device) -> Result<candle_core::Tensor> {
         todo!()
     }
 }
@@ -255,7 +255,7 @@ impl Tokenizer for CharPairTokenizer {
         Ok(result.into_iter().collect())
     }
 
-    fn into_tensor(self, _device: &candle_core::Device) -> Result<candle_core::Tensor> {
+    fn as_tensor(&self, _device: &candle_core::Device) -> Result<candle_core::Tensor> {
         todo!()
     }
 }

--- a/gpt/gpt-core/src/pair_tokenizers.rs
+++ b/gpt/gpt-core/src/pair_tokenizers.rs
@@ -181,7 +181,7 @@ impl CharPairTokenizer {
             ));
         }
 
-        let mut tokens = initial_vocab.encode(corpus)?;
+        let mut tokens = initial_vocab.encode(corpus.as_ref())?;
 
         let mut curr_vocab_size = initial_vocab.len();
         let mut pair_to_token_map = HashMap::new();
@@ -216,7 +216,7 @@ impl CharPairTokenizer {
 
     pub fn encode<T: AsRef<str>>(&self, string: T) -> Result<Vec<u32>> {
         // This is pretty inefficient and can probably be improved a lot.
-        let tokens = self.initial_vocab.encode(string)?;
+        let tokens = self.initial_vocab.encode(string.as_ref())?;
         Ok(pair_compress(tokens, &self.pair_to_token_map))
     }
 

--- a/gpt/gpt-core/src/pair_tokenizers.rs
+++ b/gpt/gpt-core/src/pair_tokenizers.rs
@@ -196,6 +196,10 @@ impl Tokenizer for BytePairTokenizer {
         todo!()
     }
 
+    fn tokenizer_type(&self) -> crate::tokenizer::TokenizerType {
+        todo!()
+    }
+
     fn debug_vocab(&self) -> String {
         todo!()
     }
@@ -306,6 +310,10 @@ impl Tokenizer for CharPairTokenizer {
 
     fn as_tensor(&self, _device: &candle_core::Device) -> Result<candle_core::Tensor> {
         todo!()
+    }
+
+    fn tokenizer_type(&self) -> crate::tokenizer::TokenizerType {
+        crate::tokenizer::TokenizerType::CharPair
     }
 
     fn debug_vocab(&self) -> String {

--- a/gpt/gpt-core/src/tokenizer.rs
+++ b/gpt/gpt-core/src/tokenizer.rs
@@ -1,13 +1,43 @@
 use anyhow::Result;
 use candle_core::{Device, Tensor};
 
-/// Key in safetensors file to store tokenizer vocabulary.
-/// Prefixing it with "BUFFER." because this is similar to a pytorch
-/// buffer and we want to make it obvious that it's not a trainable
-/// model parameter.
-///
-/// The key's value is meant to be a Tensor returned by `Tokenizer::into_tensor()`.
-pub const TOKENIZER_VOCABULARY_KEY: &'static str = "BUFFER.tokenizer_vocabulary";
+use crate::{char_tokenizer::CharTokenizer, util::SafetensorLoader};
+
+pub enum TokenizerType {
+    Char,
+    CharPair,
+}
+
+impl TokenizerType {
+    /// Key in safetensors file to store tokenizer vocabulary.
+    /// Prefixing it with "BUFFER." because this is similar to a pytorch
+    /// buffer and we want to make it obvious that it's not a trainable
+    /// model parameter.
+    ///
+    /// The key's value is meant to be a Tensor returned by `Tokenizer::as_tensor()`.
+    pub fn safetensors_key(&self) -> &'static str {
+        match self {
+            // This doesn't have the word 'char' in it b/c it was made before we
+            // had multiple tokenizers, and we want to remain backwards-compatible.
+            TokenizerType::Char => "BUFFER.tokenizer_vocabulary",
+            TokenizerType::CharPair => "BUFFER.char_pair_tokenizer_vocabulary",
+        }
+    }
+
+    pub fn load<T: SafetensorLoader>(
+        &self,
+        safetensors: &T,
+        device: &Device,
+    ) -> Result<Box<dyn Tokenizer>> {
+        match self {
+            TokenizerType::Char => {
+                let tensor = safetensors.load_tensor(self.safetensors_key(), device)?;
+                Ok(Box::new(CharTokenizer::from_tensor(&tensor)?))
+            }
+            TokenizerType::CharPair => todo!(),
+        }
+    }
+}
 
 pub trait Tokenizer {
     fn len(&self) -> usize;
@@ -21,6 +51,8 @@ pub trait Tokenizer {
     fn decode(&self, tokens: &Vec<u32>) -> Result<String>;
 
     fn as_tensor(&self, device: &Device) -> Result<Tensor>;
+
+    fn tokenizer_type(&self) -> TokenizerType;
 
     fn debug_vocab(&self) -> String;
 }

--- a/gpt/gpt-core/src/tokenizer.rs
+++ b/gpt/gpt-core/src/tokenizer.rs
@@ -1,6 +1,14 @@
 use anyhow::Result;
 use candle_core::{Device, Tensor};
 
+/// Key in safetensors file to store tokenizer vocabulary.
+/// Prefixing it with "BUFFER." because this is similar to a pytorch
+/// buffer and we want to make it obvious that it's not a trainable
+/// model parameter.
+///
+/// The key's value is meant to be a Tensor returned by `Tokenizer::into_tensor()`.
+pub const TOKENIZER_VOCABULARY_KEY: &'static str = "BUFFER.tokenizer_vocabulary";
+
 pub trait Tokenizer {
     fn len(&self) -> usize;
 

--- a/gpt/gpt-core/src/tokenizer.rs
+++ b/gpt/gpt-core/src/tokenizer.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use candle_core::{Device, Tensor};
 
 pub trait Tokenizer {
     fn len(&self) -> usize;
@@ -10,4 +11,6 @@ pub trait Tokenizer {
     fn encode_lossy(&self, content: &str) -> Vec<u32>;
 
     fn decode(&self, tokens: &Vec<u32>) -> Result<String>;
+
+    fn into_tensor(self, device: &Device) -> Result<Tensor>;
 }

--- a/gpt/gpt-core/src/tokenizer.rs
+++ b/gpt/gpt-core/src/tokenizer.rs
@@ -3,11 +3,11 @@ use anyhow::Result;
 pub trait Tokenizer {
     fn len(&self) -> usize;
 
-    fn encode<T: AsRef<str>>(&self, content: T) -> Result<Vec<u32>>;
+    fn encode(&self, content: &str) -> Result<Vec<u32>>;
 
     /// Like `encode` but filters out any content that doesn't map to a
     /// token in the vocabulary.
-    fn encode_lossy<T: AsRef<str>>(&self, content: T) -> Vec<u32>;
+    fn encode_lossy(&self, content: &str) -> Vec<u32>;
 
     fn decode(&self, tokens: &Vec<u32>) -> Result<String>;
 }

--- a/gpt/gpt-core/src/tokenizer.rs
+++ b/gpt/gpt-core/src/tokenizer.rs
@@ -21,4 +21,6 @@ pub trait Tokenizer {
     fn decode(&self, tokens: &Vec<u32>) -> Result<String>;
 
     fn as_tensor(&self, device: &Device) -> Result<Tensor>;
+
+    fn debug_vocab(&self) -> String;
 }

--- a/gpt/gpt-core/src/tokenizer.rs
+++ b/gpt/gpt-core/src/tokenizer.rs
@@ -1,0 +1,13 @@
+use anyhow::Result;
+
+pub trait Tokenizer {
+    fn len(&self) -> usize;
+
+    fn encode<T: AsRef<str>>(&self, content: T) -> Result<Vec<u32>>;
+
+    /// Like `encode` but filters out any content that doesn't map to a
+    /// token in the vocabulary.
+    fn encode_lossy<T: AsRef<str>>(&self, content: T) -> Vec<u32>;
+
+    fn decode(&self, tokens: &Vec<u32>) -> Result<String>;
+}

--- a/gpt/gpt-core/src/tokenizer.rs
+++ b/gpt/gpt-core/src/tokenizer.rs
@@ -1,15 +1,6 @@
 use anyhow::Result;
-use candle_core::Tensor;
 
-/// Key in safetensors file to store tokenizer vocabulary.
-/// Prefixing it with "BUFFER." because this is similar to a pytorch
-/// buffer and we want to make it obvious that it's not a trainable
-/// model parameter.
-///
-/// The key's value is meant to be a Tensor returned by `Tokenizer::into_tensor()`.
-pub const TOKENIZER_VOCABULARY_KEY: &'static str = "BUFFER.tokenizer_vocabulary";
-
-pub trait Tokenizer: TryFrom<Tensor> + TryInto<Tensor> {
+pub trait Tokenizer {
     fn len(&self) -> usize;
 
     fn encode<T: AsRef<str>>(&self, content: T) -> Result<Vec<u32>>;

--- a/gpt/gpt-core/src/tokenizer.rs
+++ b/gpt/gpt-core/src/tokenizer.rs
@@ -12,5 +12,5 @@ pub trait Tokenizer {
 
     fn decode(&self, tokens: &Vec<u32>) -> Result<String>;
 
-    fn into_tensor(self, device: &Device) -> Result<Tensor>;
+    fn as_tensor(&self, device: &Device) -> Result<Tensor>;
 }

--- a/gpt/gpt-core/src/tokenizer.rs
+++ b/gpt/gpt-core/src/tokenizer.rs
@@ -1,6 +1,15 @@
 use anyhow::Result;
+use candle_core::Tensor;
 
-pub trait Tokenizer {
+/// Key in safetensors file to store tokenizer vocabulary.
+/// Prefixing it with "BUFFER." because this is similar to a pytorch
+/// buffer and we want to make it obvious that it's not a trainable
+/// model parameter.
+///
+/// The key's value is meant to be a Tensor returned by `Tokenizer::into_tensor()`.
+pub const TOKENIZER_VOCABULARY_KEY: &'static str = "BUFFER.tokenizer_vocabulary";
+
+pub trait Tokenizer: TryFrom<Tensor> + TryInto<Tensor> {
     fn len(&self) -> usize;
 
     fn encode<T: AsRef<str>>(&self, content: T) -> Result<Vec<u32>>;

--- a/gpt/web/src/lib.rs
+++ b/gpt/web/src/lib.rs
@@ -1,10 +1,10 @@
 use candle_core::{DType, Device};
 use candle_nn::{VarBuilder, VarMap};
 use gpt_core::{
-    char_tokenizer::CharTokenizer,
+    char_tokenizer::{CHAR_TOKENIZER_VOCABULARY_KEY, CharTokenizer},
     language_model::LanguageGenerator,
     language_model_builder::LanguageModelBuilder,
-    tokenizer::{TOKENIZER_VOCABULARY_KEY, Tokenizer},
+    tokenizer::Tokenizer,
     transformer_language_model::TransformerLanguageModelOptions,
     util::load_data_from_safetensors,
 };
@@ -56,8 +56,8 @@ impl WasmLanguageModel {
         let safetensors = candle_core::safetensors::SliceSafetensors::new(safetensors_u8.into())?;
         let mut varmap = VarMap::new();
         let vb = VarBuilder::from_varmap(&varmap, DType::F32, &device);
-        let tokenizer_tensor = safetensors.load(TOKENIZER_VOCABULARY_KEY, &device)?;
-        let tokenizer = CharTokenizer::try_from(tokenizer_tensor).map_err(e)?;
+        let tokenizer_tensor = safetensors.load(CHAR_TOKENIZER_VOCABULARY_KEY, &device)?;
+        let tokenizer = CharTokenizer::from_tensor(&tokenizer_tensor).map_err(e)?;
         let builder = factory(tokenizer.len());
 
         builder.build(vb).map_err(e)?;

--- a/gpt/web/src/lib.rs
+++ b/gpt/web/src/lib.rs
@@ -4,6 +4,7 @@ use gpt_core::{
     char_tokenizer::{CHAR_TOKENIZER_VOCABULARY_KEY, CharTokenizer},
     language_model::LanguageGenerator,
     language_model_builder::LanguageModelBuilder,
+    tokenizer::Tokenizer,
     transformer_language_model::TransformerLanguageModelOptions,
     util::load_data_from_safetensors,
 };
@@ -82,7 +83,7 @@ impl WasmLanguageModel {
             .build_no_grad(&self.varmap, &device)
             .map_err(e)?;
 
-        let context = self.tokenizer.encode_safe(initial_context);
+        let context = self.tokenizer.encode_lossy(initial_context);
         let block_size = model.block_size();
         let generator = LanguageGenerator::new(&context, model, block_size).map_err(e)?;
         Ok(WasmLanguageGenerator::create(

--- a/gpt/web/src/lib.rs
+++ b/gpt/web/src/lib.rs
@@ -1,10 +1,10 @@
 use candle_core::{DType, Device};
 use candle_nn::{VarBuilder, VarMap};
 use gpt_core::{
-    char_tokenizer::{CHAR_TOKENIZER_VOCABULARY_KEY, CharTokenizer},
+    char_tokenizer::CharTokenizer,
     language_model::LanguageGenerator,
     language_model_builder::LanguageModelBuilder,
-    tokenizer::Tokenizer,
+    tokenizer::{TOKENIZER_VOCABULARY_KEY, Tokenizer},
     transformer_language_model::TransformerLanguageModelOptions,
     util::load_data_from_safetensors,
 };
@@ -56,8 +56,8 @@ impl WasmLanguageModel {
         let safetensors = candle_core::safetensors::SliceSafetensors::new(safetensors_u8.into())?;
         let mut varmap = VarMap::new();
         let vb = VarBuilder::from_varmap(&varmap, DType::F32, &device);
-        let tokenizer_tensor = safetensors.load(CHAR_TOKENIZER_VOCABULARY_KEY, &device)?;
-        let tokenizer = CharTokenizer::from_tensor(&tokenizer_tensor).map_err(e)?;
+        let tokenizer_tensor = safetensors.load(TOKENIZER_VOCABULARY_KEY, &device)?;
+        let tokenizer = CharTokenizer::try_from(tokenizer_tensor).map_err(e)?;
         let builder = factory(tokenizer.len());
 
         builder.build(vb).map_err(e)?;

--- a/gpt/web/src/lib.rs
+++ b/gpt/web/src/lib.rs
@@ -3,10 +3,10 @@ use std::rc::Rc;
 use candle_core::{DType, Device};
 use candle_nn::{VarBuilder, VarMap};
 use gpt_core::{
-    char_tokenizer::{CHAR_TOKENIZER_VOCABULARY_KEY, CharTokenizer},
+    char_tokenizer::CharTokenizer,
     language_model::LanguageGenerator,
     language_model_builder::LanguageModelBuilder,
-    tokenizer::Tokenizer,
+    tokenizer::{TOKENIZER_VOCABULARY_KEY, Tokenizer},
     transformer_language_model::TransformerLanguageModelOptions,
     util::load_data_from_safetensors,
 };
@@ -58,7 +58,7 @@ impl WasmLanguageModel {
         let safetensors = candle_core::safetensors::SliceSafetensors::new(safetensors_u8.into())?;
         let mut varmap = VarMap::new();
         let vb = VarBuilder::from_varmap(&varmap, DType::F32, &device);
-        let tokenizer_tensor = safetensors.load(CHAR_TOKENIZER_VOCABULARY_KEY, &device)?;
+        let tokenizer_tensor = safetensors.load(TOKENIZER_VOCABULARY_KEY, &device)?;
         let tokenizer: Rc<Box<dyn Tokenizer>> = Rc::new(Box::new(
             CharTokenizer::from_tensor(&tokenizer_tensor).map_err(e)?,
         ));

--- a/gpt/web/src/lib.rs
+++ b/gpt/web/src/lib.rs
@@ -3,10 +3,9 @@ use std::rc::Rc;
 use candle_core::{DType, Device};
 use candle_nn::{VarBuilder, VarMap};
 use gpt_core::{
-    char_tokenizer::CharTokenizer,
     language_model::LanguageGenerator,
     language_model_builder::LanguageModelBuilder,
-    tokenizer::{TOKENIZER_VOCABULARY_KEY, Tokenizer},
+    tokenizer::{Tokenizer, TokenizerType},
     transformer_language_model::TransformerLanguageModelOptions,
     util::load_data_from_safetensors,
 };
@@ -58,10 +57,7 @@ impl WasmLanguageModel {
         let safetensors = candle_core::safetensors::SliceSafetensors::new(safetensors_u8.into())?;
         let mut varmap = VarMap::new();
         let vb = VarBuilder::from_varmap(&varmap, DType::F32, &device);
-        let tokenizer_tensor = safetensors.load(TOKENIZER_VOCABULARY_KEY, &device)?;
-        let tokenizer: Rc<Box<dyn Tokenizer>> = Rc::new(Box::new(
-            CharTokenizer::from_tensor(&tokenizer_tensor).map_err(e)?,
-        ));
+        let tokenizer = Rc::new(TokenizerType::Char.load(&safetensors, &device).map_err(e)?);
         let builder = factory(tokenizer.len());
 
         builder.build(vb).map_err(e)?;


### PR DESCRIPTION
This adds new flags to the CLI which allow the use of new tokenizers:

* `--tokenizer` can be `char` (the default) or `char-pair-alpha`.
* `--vocab-size` specifies how many tokens should be in the vocabulary if the tokenizer is `char-pair-alpha` (default 300).

`char-pair-alpha` builds on the `char` tokenizer by pairwise-encoding high-frequency consecutive alphabetic characters in the training corpus.

I also added a new byte pair tokenizer, but it's not exposed via the CLI because I don't really need it right now (I mostly did it just to put the ideas from Karpathy's GPT tokenizer lecture into practice).

This also uses MessagePack to serialize the `char-pair-alpha` tokenizer into the safetensors file, which feels kind of gross, but I really don't want to have to save/load to/from two separate files per model.  Theoretically safetensors does support metadata strings, so we could serialize JSON into them, but Candle makes it difficult to access those, so I'm just using tensors for now.

To try this out, you can train a model with:

```
cargo run --release -- --tokenizer=char-pair-alpha --save=pair
```

Then you can run the model with:

```
cargo run --release -- --load=pair --epochs=0
```
